### PR TITLE
SRE-1942 Backport delete_on_termination attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Attribute Parameters:
 * `existing_raid` - whether or not to assume the raid was previously assembled on existing volumes (default no)
 * `encrypted` - specify if the EBS should be encrypted
 * `kms_key_id` - the full ARN of the AWS Key Management Service (AWS KMS) master key to use when creating the encrypted volume (defaults to master key if not specified)
+* `delete_on_termination` - Boolean value to control whether or not the volume should be deleted when the instance it's attached to is terminated (defaults to nil). Only applies to `:attach` action.
 
 ## ebs_raid.rb
 

--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -68,6 +68,7 @@ action :attach do
     converge_by("attach the volume with aws_id=#{vol[:volume_id]} id=#{instance_id} device=#{new_resource.device} and update the node data with created volume's id") do
       # attach the volume and register its id in the node data
       attach_volume(vol[:volume_id], instance_id, new_resource.device, new_resource.timeout)
+      mark_delete_on_termination(new_resource.device, vol[:volume_id], instance_id) if new_resource.delete_on_termination
       # always use a symbol here, it is a Hash
       node.set['aws']['ebs_volume'][new_resource.name]['volume_id'] = vol[:volume_id]
       node.save unless Chef::Config[:solo]
@@ -268,4 +269,9 @@ def detach_volume(volume_id, timeout)
   rescue Timeout::Error
     raise "Timed out waiting for volume detachment after #{timeout} seconds"
   end
+end
+
+def mark_delete_on_termination(device_name, volume_id, instance_id)
+  Chef::Log.debug("Marking volume #{volume_id} with device name #{device_name} attached to instance #{instance_id} #{new_resource.delete_on_termination} for deletion on instance termination")
+  ec2.modify_instance_attribute(block_device_mappings: [{ device_name: device_name, ebs: { volume_id: volume_id, delete_on_termination: new_resource.delete_on_termination } }], instance_id: instance_id)
 end

--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -12,7 +12,8 @@ state_attrs :availability_zone,
             :timeout,
             :volume_id,
             :volume_type,
-            :encrypted
+            :encrypted,
+            :delete_on_termination
 
 attribute :aws_access_key,        kind_of: String
 attribute :aws_secret_access_key, kind_of: String
@@ -30,6 +31,7 @@ attribute :volume_type,           kind_of: String, default: 'standard'
 attribute :piops,                 kind_of: Integer, default: 0
 attribute :encrypted,             kind_of: [TrueClass, FalseClass], default: false
 attribute :kms_key_id,            kind_of: String
+attribute :delete_on_termination, kind_of: [TrueClass, FalseClass], default: false
 
 def initialize(*args)
   super


### PR DESCRIPTION
We can't upgrade to a newer AWS cookbook because it depends on a newer version of the `ohai` cookbook than we're willing to upgrade to right now (because our `nginx` cookbook requires an old `ohai`), but we want to be able to mark EBS volumes to terminate with their associated instances. This backports the `:delete_on_termination` attribute from v4.1.1 of the AWS cookbook to our v2.7.2 fork.